### PR TITLE
Use DelayedVestingAccount when there is 1 non-genesis distribution

### DIFF
--- a/account.go
+++ b/account.go
@@ -214,8 +214,18 @@ func ToCosmosAccount(acc Account, genesisTime time.Time) (auth.AccountI, *bank.B
 	startTime := genesisTime
 
 	// if we have one distribution and it happens before or at genesis return a basic BaseAccount
-	if len(acc.Distributions) == 1 && !acc.Distributions[0].Time.After(genesisTime) {
-		return &auth.BaseAccount{Address: addrStr}, balance, nil
+	if len(acc.Distributions) == 1 {
+		if !acc.Distributions[0].Time.After(genesisTime) {
+			return &auth.BaseAccount{Address: addrStr}, balance, nil
+		} else {
+			return &vesting.DelayedVestingAccount{
+				BaseVestingAccount: &vesting.BaseVestingAccount{
+					BaseAccount:     &auth.BaseAccount{Address: addrStr},
+					OriginalVesting: totalCoins,
+					EndTime:         acc.Distributions[0].Time.Unix(),
+				},
+			}, balance, nil
+		}
 	} else {
 		periodStart := startTime
 

--- a/account.go
+++ b/account.go
@@ -211,7 +211,7 @@ func ToCosmosAccount(acc Account, genesisTime time.Time) (auth.AccountI, *bank.B
 		return &auth.BaseAccount{Address: addrStr}, balance, nil
 	}
 
-	startTime := genesisTime
+	startTime := acc.Distributions[0].Time
 
 	// if we have one distribution and it happens before or at genesis return a basic BaseAccount
 	if len(acc.Distributions) == 1 {

--- a/account.go
+++ b/account.go
@@ -211,10 +211,10 @@ func ToCosmosAccount(acc Account, genesisTime time.Time) (auth.AccountI, *bank.B
 		return &auth.BaseAccount{Address: addrStr}, balance, nil
 	}
 
-	startTime := acc.Distributions[0].Time
+	startTime := genesisTime
 
 	// if we have one distribution and it happens before or at genesis return a basic BaseAccount
-	if len(acc.Distributions) == 1 && !startTime.After(genesisTime) {
+	if len(acc.Distributions) == 1 && !acc.Distributions[0].Time.After(genesisTime) {
 		return &auth.BaseAccount{Address: addrStr}, balance, nil
 	} else {
 		periodStart := startTime

--- a/account_test.go
+++ b/account_test.go
@@ -109,10 +109,10 @@ func TestToCosmosAccount(t *testing.T) {
 					OriginalVesting: sdk.NewCoins(sdk.NewInt64Coin(URegenDenom, 5000000)),
 					EndTime:         time1.Unix(),
 				},
-				StartTime: time1.Unix(),
+				StartTime: time0.Unix(),
 				VestingPeriods: []vesting.Period{
 					{
-						Length: 0,
+						Length: int64(time1.Sub(time0).Seconds()),
 						Amount: sdk.NewCoins(sdk.NewInt64Coin(URegenDenom, 5000000)),
 					},
 				},

--- a/account_test.go
+++ b/account_test.go
@@ -101,20 +101,13 @@ func TestToCosmosAccount(t *testing.T) {
 					},
 				},
 			},
-			&vesting.PeriodicVestingAccount{
+			&vesting.DelayedVestingAccount{
 				BaseVestingAccount: &vesting.BaseVestingAccount{
 					BaseAccount: &auth.BaseAccount{
 						Address: addr1.String(),
 					},
 					OriginalVesting: sdk.NewCoins(sdk.NewInt64Coin(URegenDenom, 5000000)),
 					EndTime:         time1.Unix(),
-				},
-				StartTime: time0.Unix(),
-				VestingPeriods: []vesting.Period{
-					{
-						Length: int64(time1.Sub(time0).Seconds()),
-						Amount: sdk.NewCoins(sdk.NewInt64Coin(URegenDenom, 5000000)),
-					},
 				},
 			},
 			&bank.Balance{

--- a/main.go
+++ b/main.go
@@ -132,6 +132,14 @@ func buildAccounts(accountsCsv io.Reader, genesisTime time.Time, auditOutput io.
 			return nil, nil, fmt.Errorf("error on ToCosmosAccount: %w", err)
 		}
 
+		genAcc, ok := authAcc.(auth.GenesisAccount)
+		if ok {
+			err = genAcc.Validate()
+			if err != nil {
+				return nil, nil, err
+			}
+		}
+
 		err = ValidateVestingAccount(authAcc)
 		if err != nil {
 			return nil, nil, err


### PR DESCRIPTION
After running the genesis script to create a genesis.json file, i ran `regen validate-genesis` to manually validate the generated genesis file and got the following error:
```
Error: error validating genesis file regen-prelaunch-1/genesis.json: invalid account found
in genesis state; address: regen16fa0zwa2gc6et49u9mjq3wnycn7t8j049jduyt, error: vesting
start-time cannot be before end-time
```

So this error is actually incorrect, it says "vesting start-time cannot be before end-time" but the issue is actually that "vesting start-time cannot be equal to or after end-time". Hence, for all "Single distribution" events where we give a person one discrete dump of tokens at a post-genesis date, we were getting this error as `startTime == endTime` under our current logic.

The solution here sets all VestingAccount's `startTime` values to `genesisTime`. This makes more logical sense to me, as `startTime` imo is intended to represent the start of lockup. This also gets rid of the all situations where a `period.Length == 0`, as if we grant all users their full balance at genesis we instead just create a BaseAccount with a fully unlocked balance.

One alternative would be to use a `DiscreteVestingAccount` for these cases, but I prefer this solution.

I reran `regen validate-genesis` on this branch and successfully validated the generated genesis file. If you're attempting to verify this yourself make sure to build a new `regen-ledger` from master as we only recently removed CosmWasm from the stable build and i was getting obscure `EOF` errors due to not having `wasm` app state in genesis (took me a very long time to debug this....)

